### PR TITLE
✨ (go/v4): Remove hard-coded license details from the script template.

### DIFF
--- a/.github/workflows/test-devcontainer.yaml
+++ b/.github/workflows/test-devcontainer.yaml
@@ -16,7 +16,6 @@ jobs:
         with:
           go-version: "1.22.x"
 
-      # required for installing devcontainer CLI
       - name: Setup NodeJS 20.x
         uses: actions/setup-node@v4
         with:

--- a/docs/book/src/cronjob-tutorial/testdata/project/.devcontainer/devcontainer.json
+++ b/docs/book/src/cronjob-tutorial/testdata/project/.devcontainer/devcontainer.json
@@ -1,12 +1,11 @@
 {
   "name": "Kubebuilder DevContainer",
-  "image": "golang:1.22-bullseye",
+  "image": "golang:1.22",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/git:1": {}
   },
 
-  // Required for running Kind inside DevContainer
   "runArgs": ["--network=host"],
 
   "customizations": {

--- a/docs/book/src/cronjob-tutorial/testdata/project/.devcontainer/post-install.sh
+++ b/docs/book/src/cronjob-tutorial/testdata/project/.devcontainer/post-install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -x
 
-curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.24.0/kind-linux-amd64
+curl -Lo ./kind https://kind.sigs.k8s.io/dl/latest/kind-linux-amd64
 chmod +x ./kind
 mv ./kind /usr/local/bin/kind
 

--- a/docs/book/src/cronjob-tutorial/testdata/project/.devcontainer/post-install.sh
+++ b/docs/book/src/cronjob-tutorial/testdata/project/.devcontainer/post-install.sh
@@ -1,18 +1,4 @@
 #!/bin/bash
-# Copyright 2024 The Kubernetes Authors.
-
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-
-#     http://www.apache.org/licenses/LICENSE-2.0
-
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 set -x
 
 curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.24.0/kind-linux-amd64
@@ -23,7 +9,8 @@ curl -L -o kubebuilder https://go.kubebuilder.io/dl/latest/linux/amd64
 chmod +x kubebuilder
 mv kubebuilder /usr/local/bin/
 
-curl -L -o kubectl https://dl.k8s.io/release/v1.31.0/bin/linux/amd64/kubectl
+KUBECTL_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
+curl -LO "https://dl.k8s.io/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl"
 chmod +x kubectl
 mv kubectl /usr/local/bin/kubectl
 

--- a/docs/book/src/getting-started/testdata/project/.devcontainer/devcontainer.json
+++ b/docs/book/src/getting-started/testdata/project/.devcontainer/devcontainer.json
@@ -1,12 +1,11 @@
 {
   "name": "Kubebuilder DevContainer",
-  "image": "golang:1.22-bullseye",
+  "image": "golang:1.22",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/git:1": {}
   },
 
-  // Required for running Kind inside DevContainer
   "runArgs": ["--network=host"],
 
   "customizations": {

--- a/docs/book/src/getting-started/testdata/project/.devcontainer/post-install.sh
+++ b/docs/book/src/getting-started/testdata/project/.devcontainer/post-install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -x
 
-curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.24.0/kind-linux-amd64
+curl -Lo ./kind https://kind.sigs.k8s.io/dl/latest/kind-linux-amd64
 chmod +x ./kind
 mv ./kind /usr/local/bin/kind
 

--- a/docs/book/src/getting-started/testdata/project/.devcontainer/post-install.sh
+++ b/docs/book/src/getting-started/testdata/project/.devcontainer/post-install.sh
@@ -1,18 +1,4 @@
 #!/bin/bash
-# Copyright 2024 The Kubernetes Authors.
-
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-
-#     http://www.apache.org/licenses/LICENSE-2.0
-
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 set -x
 
 curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.24.0/kind-linux-amd64
@@ -23,7 +9,8 @@ curl -L -o kubebuilder https://go.kubebuilder.io/dl/latest/linux/amd64
 chmod +x kubebuilder
 mv kubebuilder /usr/local/bin/
 
-curl -L -o kubectl https://dl.k8s.io/release/v1.31.0/bin/linux/amd64/kubectl
+KUBECTL_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
+curl -LO "https://dl.k8s.io/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl"
 chmod +x kubectl
 mv kubectl /usr/local/bin/kubectl
 

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/devcontainer.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/devcontainer.go
@@ -22,13 +22,12 @@ import (
 
 const devContainerTemplate = `{
   "name": "Kubebuilder DevContainer",
-  "image": "golang:1.22-bullseye",
+  "image": "golang:1.22",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/git:1": {}
   },
 
-  // Required for running Kind inside DevContainer
   "runArgs": ["--network=host"],
 
   "customizations": {
@@ -49,23 +48,9 @@ const devContainerTemplate = `{
 `
 
 const postInstallScript = `#!/bin/bash
-# Copyright 2024 The Kubernetes Authors.
-
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-
-#     http://www.apache.org/licenses/LICENSE-2.0
-
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 set -x
 
-curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.24.0/kind-linux-amd64
+curl -Lo ./kind https://kind.sigs.k8s.io/dl/latest/kind-linux-amd64
 chmod +x ./kind
 mv ./kind /usr/local/bin/kind
 
@@ -73,7 +58,8 @@ curl -L -o kubebuilder https://go.kubebuilder.io/dl/latest/linux/amd64
 chmod +x kubebuilder
 mv kubebuilder /usr/local/bin/
 
-curl -L -o kubectl https://dl.k8s.io/release/v1.31.0/bin/linux/amd64/kubectl
+KUBECTL_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
+curl -LO "https://dl.k8s.io/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl"
 chmod +x kubectl
 mv kubectl /usr/local/bin/kubectl
 

--- a/test/check-license.sh
+++ b/test/check-license.sh
@@ -21,7 +21,7 @@ set -o pipefail
 source $(dirname "$0")/common.sh
 
 echo "Checking for license header..."
-allfiles=$(listFiles|grep -v ./internal/bindata/...)
+allfiles=$(listFiles | grep -v -e './internal/bindata/...' -e '.devcontainer/post-install.sh')
 licRes=""
 for file in $allfiles; do
   if ! head -n4 "${file}" | grep -Eq "(Copyright|generated|GENERATED|Licensed)" ; then

--- a/testdata/project-v4-multigroup-with-deploy-image/.devcontainer/devcontainer.json
+++ b/testdata/project-v4-multigroup-with-deploy-image/.devcontainer/devcontainer.json
@@ -1,12 +1,11 @@
 {
   "name": "Kubebuilder DevContainer",
-  "image": "golang:1.22-bullseye",
+  "image": "golang:1.22",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/git:1": {}
   },
 
-  // Required for running Kind inside DevContainer
   "runArgs": ["--network=host"],
 
   "customizations": {

--- a/testdata/project-v4-multigroup-with-deploy-image/.devcontainer/post-install.sh
+++ b/testdata/project-v4-multigroup-with-deploy-image/.devcontainer/post-install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -x
 
-curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.24.0/kind-linux-amd64
+curl -Lo ./kind https://kind.sigs.k8s.io/dl/latest/kind-linux-amd64
 chmod +x ./kind
 mv ./kind /usr/local/bin/kind
 

--- a/testdata/project-v4-multigroup-with-deploy-image/.devcontainer/post-install.sh
+++ b/testdata/project-v4-multigroup-with-deploy-image/.devcontainer/post-install.sh
@@ -1,18 +1,4 @@
 #!/bin/bash
-# Copyright 2024 The Kubernetes Authors.
-
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-
-#     http://www.apache.org/licenses/LICENSE-2.0
-
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 set -x
 
 curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.24.0/kind-linux-amd64
@@ -23,7 +9,8 @@ curl -L -o kubebuilder https://go.kubebuilder.io/dl/latest/linux/amd64
 chmod +x kubebuilder
 mv kubebuilder /usr/local/bin/
 
-curl -L -o kubectl https://dl.k8s.io/release/v1.31.0/bin/linux/amd64/kubectl
+KUBECTL_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
+curl -LO "https://dl.k8s.io/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl"
 chmod +x kubectl
 mv kubectl /usr/local/bin/kubectl
 

--- a/testdata/project-v4-multigroup/.devcontainer/devcontainer.json
+++ b/testdata/project-v4-multigroup/.devcontainer/devcontainer.json
@@ -1,12 +1,11 @@
 {
   "name": "Kubebuilder DevContainer",
-  "image": "golang:1.22-bullseye",
+  "image": "golang:1.22",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/git:1": {}
   },
 
-  // Required for running Kind inside DevContainer
   "runArgs": ["--network=host"],
 
   "customizations": {

--- a/testdata/project-v4-multigroup/.devcontainer/post-install.sh
+++ b/testdata/project-v4-multigroup/.devcontainer/post-install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -x
 
-curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.24.0/kind-linux-amd64
+curl -Lo ./kind https://kind.sigs.k8s.io/dl/latest/kind-linux-amd64
 chmod +x ./kind
 mv ./kind /usr/local/bin/kind
 

--- a/testdata/project-v4-multigroup/.devcontainer/post-install.sh
+++ b/testdata/project-v4-multigroup/.devcontainer/post-install.sh
@@ -1,18 +1,4 @@
 #!/bin/bash
-# Copyright 2024 The Kubernetes Authors.
-
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-
-#     http://www.apache.org/licenses/LICENSE-2.0
-
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 set -x
 
 curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.24.0/kind-linux-amd64
@@ -23,7 +9,8 @@ curl -L -o kubebuilder https://go.kubebuilder.io/dl/latest/linux/amd64
 chmod +x kubebuilder
 mv kubebuilder /usr/local/bin/
 
-curl -L -o kubectl https://dl.k8s.io/release/v1.31.0/bin/linux/amd64/kubectl
+KUBECTL_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
+curl -LO "https://dl.k8s.io/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl"
 chmod +x kubectl
 mv kubectl /usr/local/bin/kubectl
 

--- a/testdata/project-v4-with-deploy-image/.devcontainer/devcontainer.json
+++ b/testdata/project-v4-with-deploy-image/.devcontainer/devcontainer.json
@@ -1,12 +1,11 @@
 {
   "name": "Kubebuilder DevContainer",
-  "image": "golang:1.22-bullseye",
+  "image": "golang:1.22",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/git:1": {}
   },
 
-  // Required for running Kind inside DevContainer
   "runArgs": ["--network=host"],
 
   "customizations": {

--- a/testdata/project-v4-with-deploy-image/.devcontainer/post-install.sh
+++ b/testdata/project-v4-with-deploy-image/.devcontainer/post-install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -x
 
-curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.24.0/kind-linux-amd64
+curl -Lo ./kind https://kind.sigs.k8s.io/dl/latest/kind-linux-amd64
 chmod +x ./kind
 mv ./kind /usr/local/bin/kind
 

--- a/testdata/project-v4-with-deploy-image/.devcontainer/post-install.sh
+++ b/testdata/project-v4-with-deploy-image/.devcontainer/post-install.sh
@@ -1,18 +1,4 @@
 #!/bin/bash
-# Copyright 2024 The Kubernetes Authors.
-
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-
-#     http://www.apache.org/licenses/LICENSE-2.0
-
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 set -x
 
 curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.24.0/kind-linux-amd64
@@ -23,7 +9,8 @@ curl -L -o kubebuilder https://go.kubebuilder.io/dl/latest/linux/amd64
 chmod +x kubebuilder
 mv kubebuilder /usr/local/bin/
 
-curl -L -o kubectl https://dl.k8s.io/release/v1.31.0/bin/linux/amd64/kubectl
+KUBECTL_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
+curl -LO "https://dl.k8s.io/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl"
 chmod +x kubectl
 mv kubectl /usr/local/bin/kubectl
 

--- a/testdata/project-v4-with-grafana/.devcontainer/devcontainer.json
+++ b/testdata/project-v4-with-grafana/.devcontainer/devcontainer.json
@@ -1,12 +1,11 @@
 {
   "name": "Kubebuilder DevContainer",
-  "image": "golang:1.22-bullseye",
+  "image": "golang:1.22",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/git:1": {}
   },
 
-  // Required for running Kind inside DevContainer
   "runArgs": ["--network=host"],
 
   "customizations": {

--- a/testdata/project-v4-with-grafana/.devcontainer/post-install.sh
+++ b/testdata/project-v4-with-grafana/.devcontainer/post-install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -x
 
-curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.24.0/kind-linux-amd64
+curl -Lo ./kind https://kind.sigs.k8s.io/dl/latest/kind-linux-amd64
 chmod +x ./kind
 mv ./kind /usr/local/bin/kind
 

--- a/testdata/project-v4-with-grafana/.devcontainer/post-install.sh
+++ b/testdata/project-v4-with-grafana/.devcontainer/post-install.sh
@@ -1,18 +1,4 @@
 #!/bin/bash
-# Copyright 2024 The Kubernetes Authors.
-
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-
-#     http://www.apache.org/licenses/LICENSE-2.0
-
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 set -x
 
 curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.24.0/kind-linux-amd64
@@ -23,7 +9,8 @@ curl -L -o kubebuilder https://go.kubebuilder.io/dl/latest/linux/amd64
 chmod +x kubebuilder
 mv kubebuilder /usr/local/bin/
 
-curl -L -o kubectl https://dl.k8s.io/release/v1.31.0/bin/linux/amd64/kubectl
+KUBECTL_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
+curl -LO "https://dl.k8s.io/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl"
 chmod +x kubectl
 mv kubectl /usr/local/bin/kubectl
 

--- a/testdata/project-v4/.devcontainer/devcontainer.json
+++ b/testdata/project-v4/.devcontainer/devcontainer.json
@@ -1,12 +1,11 @@
 {
   "name": "Kubebuilder DevContainer",
-  "image": "golang:1.22-bullseye",
+  "image": "golang:1.22",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/git:1": {}
   },
 
-  // Required for running Kind inside DevContainer
   "runArgs": ["--network=host"],
 
   "customizations": {

--- a/testdata/project-v4/.devcontainer/post-install.sh
+++ b/testdata/project-v4/.devcontainer/post-install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -x
 
-curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.24.0/kind-linux-amd64
+curl -Lo ./kind https://kind.sigs.k8s.io/dl/latest/kind-linux-amd64
 chmod +x ./kind
 mv ./kind /usr/local/bin/kind
 

--- a/testdata/project-v4/.devcontainer/post-install.sh
+++ b/testdata/project-v4/.devcontainer/post-install.sh
@@ -1,18 +1,4 @@
 #!/bin/bash
-# Copyright 2024 The Kubernetes Authors.
-
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-
-#     http://www.apache.org/licenses/LICENSE-2.0
-
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 set -x
 
 curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.24.0/kind-linux-amd64
@@ -23,7 +9,8 @@ curl -L -o kubebuilder https://go.kubebuilder.io/dl/latest/linux/amd64
 chmod +x kubebuilder
 mv kubebuilder /usr/local/bin/
 
-curl -L -o kubectl https://dl.k8s.io/release/v1.31.0/bin/linux/amd64/kubectl
+KUBECTL_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
+curl -LO "https://dl.k8s.io/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl"
 chmod +x kubectl
 mv kubectl /usr/local/bin/kubectl
 


### PR DESCRIPTION
<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->

# Description
This PR add the functionality of generating DevContainer configuration files along with rest of the Kubebuilder project during scaffolding.

# Motivation
DevContainer is an Open Source tool which allows users consolidate their development environment into single container image. This image then can be shared across any environment by anyone. DevContainers can then be launched using any IDE including VSCode. Github's CodeSpaces uses the same tech underline.

In the context of Kubebuilder, having a DevContainer with Kind, Go, and Kubebuilder will allow any user to readily test their Operator's changes without installing any of the tools explicitly, thereby saving the time.