### PR TITLE
🐛 (go/v4): Fix Kind networking issue in GH CodeSpaces.

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/.devcontainer/post-install.sh
+++ b/docs/book/src/cronjob-tutorial/testdata/project/.devcontainer/post-install.sh
@@ -14,6 +14,8 @@ curl -LO "https://dl.k8s.io/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl"
 chmod +x kubectl
 mv kubectl /usr/local/bin/kubectl
 
+docker network create -d=bridge --subnet=172.19.0.0/24 kind
+
 kind version
 kubebuilder version
 docker --version

--- a/docs/book/src/getting-started/testdata/project/.devcontainer/post-install.sh
+++ b/docs/book/src/getting-started/testdata/project/.devcontainer/post-install.sh
@@ -14,6 +14,8 @@ curl -LO "https://dl.k8s.io/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl"
 chmod +x kubectl
 mv kubectl /usr/local/bin/kubectl
 
+docker network create -d=bridge --subnet=172.19.0.0/24 kind
+
 kind version
 kubebuilder version
 docker --version

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/devcontainer.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/devcontainer.go
@@ -63,6 +63,8 @@ curl -LO "https://dl.k8s.io/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl"
 chmod +x kubectl
 mv kubectl /usr/local/bin/kubectl
 
+docker network create -d=bridge --subnet=172.19.0.0/24 kind
+
 kind version
 kubebuilder version
 docker --version

--- a/testdata/project-v4-multigroup-with-deploy-image/.devcontainer/post-install.sh
+++ b/testdata/project-v4-multigroup-with-deploy-image/.devcontainer/post-install.sh
@@ -14,6 +14,8 @@ curl -LO "https://dl.k8s.io/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl"
 chmod +x kubectl
 mv kubectl /usr/local/bin/kubectl
 
+docker network create -d=bridge --subnet=172.19.0.0/24 kind
+
 kind version
 kubebuilder version
 docker --version

--- a/testdata/project-v4-multigroup/.devcontainer/post-install.sh
+++ b/testdata/project-v4-multigroup/.devcontainer/post-install.sh
@@ -14,6 +14,8 @@ curl -LO "https://dl.k8s.io/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl"
 chmod +x kubectl
 mv kubectl /usr/local/bin/kubectl
 
+docker network create -d=bridge --subnet=172.19.0.0/24 kind
+
 kind version
 kubebuilder version
 docker --version

--- a/testdata/project-v4-with-deploy-image/.devcontainer/post-install.sh
+++ b/testdata/project-v4-with-deploy-image/.devcontainer/post-install.sh
@@ -14,6 +14,8 @@ curl -LO "https://dl.k8s.io/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl"
 chmod +x kubectl
 mv kubectl /usr/local/bin/kubectl
 
+docker network create -d=bridge --subnet=172.19.0.0/24 kind
+
 kind version
 kubebuilder version
 docker --version

--- a/testdata/project-v4-with-grafana/.devcontainer/post-install.sh
+++ b/testdata/project-v4-with-grafana/.devcontainer/post-install.sh
@@ -14,6 +14,8 @@ curl -LO "https://dl.k8s.io/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl"
 chmod +x kubectl
 mv kubectl /usr/local/bin/kubectl
 
+docker network create -d=bridge --subnet=172.19.0.0/24 kind
+
 kind version
 kubebuilder version
 docker --version

--- a/testdata/project-v4/.devcontainer/post-install.sh
+++ b/testdata/project-v4/.devcontainer/post-install.sh
@@ -14,6 +14,8 @@ curl -LO "https://dl.k8s.io/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl"
 chmod +x kubectl
 mv kubectl /usr/local/bin/kubectl
 
+docker network create -d=bridge --subnet=172.19.0.0/24 kind
+
 kind version
 kubebuilder version
 docker --version


### PR DESCRIPTION
<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
# Description
This PR adds the fix for running Kind inside DevContainer in GH Code Spaces. Every time someone creates a new GH Code Space instance, and runs `kind create cluster`, they will see the following error:

![image](https://github.com/user-attachments/assets/38534d0a-bebb-45e6-80aa-ecded13a556d)

If Docker network for Kind is created explicitly 1st, followed the cluster, everything works correctly (see the `docker network create` step in `post-install.sh` script below. 
![image](https://github.com/user-attachments/assets/2e4a6dce-afa7-4118-b3d4-b276d3287982)

The fix is based on this [comment](https://github.com/kubernetes-sigs/kind/issues/2488#issuecomment-938603168). **Note that this issue doesn't appear if you the DevContainer locally**. Only happens in GH Code Spaces.